### PR TITLE
the g1 code is not interpreted, so it will execute exactly as given

### DIFF
--- a/src/raspigcd.cpp
+++ b/src/raspigcd.cpp
@@ -126,7 +126,7 @@ partitioned_program_t preprocess_program_parts(partitioned_program_t program_par
                     machine_state = last_state_after_program_execution(ppart, machine_state);
                     break;
                 case 1:
-                    ppart = g1_move_to_g1_with_machine_limits(ppart, cfg, machine_state, false);
+                    //  (DO NOT INTERPRET G1) ppart = g1_move_to_g1_with_machine_limits(ppart, cfg, machine_state, false);
                     prepared_program.insert(prepared_program.end(), ppart.begin(), ppart.end());
                     machine_state = last_state_after_program_execution(ppart, machine_state);
                     break;


### PR DESCRIPTION
In my opinion - G0 should be interpreted as separate moves, but G1 should not be interpreted, because it is the designer responsibility to make it correct.